### PR TITLE
add some operators in migrating_sse.md from sse to lsx

### DIFF
--- a/docs/migrating_sse.md
+++ b/docs/migrating_sse.md
@@ -360,27 +360,27 @@ Here is a table of a mapping from SSE intrinsics to their LSX counterpart (WIP):
 | _mm_sign_epi16          |                                       |
 | _mm_sign_epi32          |                                       |
 | _mm_sign_epi8           |                                       |
-| _mm_sll_epi16           | __lsx_vsll_h                                      |
+| _mm_sll_epi16           | __lsx_vsll_h                          |
 | _mm_sll_epi32           | __lsx_vsll_w                          |
-| _mm_sll_epi64           | __lsx_vsll_d                                      |
-| _mm_slli_epi16          | __lsx_vslli_h                                      |
+| _mm_sll_epi64           | __lsx_vsll_d                          |
+| _mm_slli_epi16          | __lsx_vslli_h                         |
 | _mm_slli_epi32          | __lsx_vslli_w                         |
-| _mm_slli_epi64          | __lsx_vslli_d                                      |
+| _mm_slli_epi64          | __lsx_vslli_d                         |
 | _mm_slli_si128          |                                       |
 | _mm_sqrt_pd             | __lsx_vfsqrt_d                        |
 | _mm_sqrt_ps             | __lsx_vfsqrt_s                        |
 | _mm_sqrt_sd             |                                       |
 | _mm_sqrt_ss             |                                       |
-| _mm_sra_epi16           | __lsx_vsra_h                                      |
-| _mm_sra_epi32           | __lsx_vsra_w                                      |
-| _mm_srai_epi16          | __lsx_vsrai_h                                      |
-| _mm_srai_epi32          | __lsx_vsrai_w                                      |
-| _mm_srl_epi16           | __lsx_vsrl_h                                      |
-| _mm_srl_epi32           | __lsx_vsrl_w                                      |
-| _mm_srl_epi64           | __lsx_vsrl_d                                      |
-| _mm_srli_epi16          | __lsx_vsrli_h                                      |
-| _mm_srli_epi32          | __lsx_vsrli_w                                      |
-| _mm_srli_epi64          | __lsx_vsrli_d                                      |
+| _mm_sra_epi16           | __lsx_vsra_h                          |
+| _mm_sra_epi32           | __lsx_vsra_w                          |
+| _mm_srai_epi16          | __lsx_vsrai_h                         |
+| _mm_srai_epi32          | __lsx_vsrai_w                         |
+| _mm_srl_epi16           | __lsx_vsrl_h                          |
+| _mm_srl_epi32           | __lsx_vsrl_w                          |
+| _mm_srl_epi64           | __lsx_vsrl_d                          |
+| _mm_srli_epi16          | __lsx_vsrli_h                         |
+| _mm_srli_epi32          | __lsx_vsrli_w                         |
+| _mm_srli_epi64          | __lsx_vsrli_d                         |
 | _mm_srli_si128          |                                       |
 | _mm_store_pd            | __lsx_vst                             |
 | _mm_store_pd1           |                                       |

--- a/docs/migrating_sse.md
+++ b/docs/migrating_sse.md
@@ -360,27 +360,27 @@ Here is a table of a mapping from SSE intrinsics to their LSX counterpart (WIP):
 | _mm_sign_epi16          |                                       |
 | _mm_sign_epi32          |                                       |
 | _mm_sign_epi8           |                                       |
-| _mm_sll_epi16           |                                       |
-| _mm_sll_epi32           |                                       |
-| _mm_sll_epi64           |                                       |
-| _mm_slli_epi16          |                                       |
-| _mm_slli_epi32          |                                       |
-| _mm_slli_epi64          |                                       |
+| _mm_sll_epi16           | __lsx_vsll_h                                      |
+| _mm_sll_epi32           | __lsx_vsll_w                          |
+| _mm_sll_epi64           | __lsx_vsll_d                                      |
+| _mm_slli_epi16          | __lsx_vslli_h                                      |
+| _mm_slli_epi32          | __lsx_vslli_w                         |
+| _mm_slli_epi64          | __lsx_vslli_d                                      |
 | _mm_slli_si128          |                                       |
 | _mm_sqrt_pd             | __lsx_vfsqrt_d                        |
 | _mm_sqrt_ps             | __lsx_vfsqrt_s                        |
 | _mm_sqrt_sd             |                                       |
 | _mm_sqrt_ss             |                                       |
-| _mm_sra_epi16           |                                       |
-| _mm_sra_epi32           |                                       |
-| _mm_srai_epi16          |                                       |
-| _mm_srai_epi32          |                                       |
-| _mm_srl_epi16           |                                       |
-| _mm_srl_epi32           |                                       |
-| _mm_srl_epi64           |                                       |
-| _mm_srli_epi16          |                                       |
-| _mm_srli_epi32          |                                       |
-| _mm_srli_epi64          |                                       |
+| _mm_sra_epi16           | __lsx_vsra_h                                      |
+| _mm_sra_epi32           | __lsx_vsra_w                                      |
+| _mm_srai_epi16          | __lsx_vsrai_h                                      |
+| _mm_srai_epi32          | __lsx_vsrai_w                                      |
+| _mm_srl_epi16           | __lsx_vsrl_h                                      |
+| _mm_srl_epi32           | __lsx_vsrl_w                                      |
+| _mm_srl_epi64           | __lsx_vsrl_d                                      |
+| _mm_srli_epi16          | __lsx_vsrli_h                                      |
+| _mm_srli_epi32          | __lsx_vsrli_w                                      |
+| _mm_srli_epi64          | __lsx_vsrli_d                                      |
 | _mm_srli_si128          |                                       |
 | _mm_store_pd            | __lsx_vst                             |
 | _mm_store_pd1           |                                       |


### PR DESCRIPTION
information from numpy
x86
![9f01cce82f1a83b86267f8bb3cc4679](https://github.com/jiegec/unofficial-loongarch-intrinsics-guide/assets/56055887/cc2785d7-0710-438b-9b8c-10933951c5a5)
lsx
![4e3664b39225e1ed5cbd047dc3c75dd](https://github.com/jiegec/unofficial-loongarch-intrinsics-guide/assets/56055887/ed361fdf-265d-4b34-b23e-d3c70a7c1651)
麻烦老师检查一下是否正确