### PR TITLE
add some infomation in migrating_sse.md from sse to lsx

### DIFF
--- a/docs/migrating_sse.md
+++ b/docs/migrating_sse.md
@@ -335,11 +335,11 @@ Here is a table of a mapping from SSE intrinsics to their LSX counterpart (WIP):
 | _mm_set_ps1             | __lsx_vdrepl_w/__lsx_vreplgr2vr_w     |
 | _mm_set_sd              |                                       |
 | _mm_set_ss              |                                       |
-| _mm_set1_epi16          |                                       |
-| _mm_set1_epi32          |                                       |
-| _mm_set1_epi64          |                                       |
+| _mm_set1_epi16          | __lsx_vreplgr2vr_h                    |
+| _mm_set1_epi32          | __lsx_vreplgr2vr_w                    |
+| _mm_set1_epi64          | __lsx_vreplgr2vr_d                    |
 | _mm_set1_epi64x         |                                       |
-| _mm_set1_epi8           |                                       |
+| _mm_set1_epi8           | __lsx_vreplgr2vr_b                    |
 | _mm_set1_pd             |                                       |
 | _mm_set1_ps             |                                       |
 | _mm_setr_epi16          |                                       |
@@ -348,9 +348,9 @@ Here is a table of a mapping from SSE intrinsics to their LSX counterpart (WIP):
 | _mm_setr_epi8           |                                       |
 | _mm_setr_pd             |                                       |
 | _mm_setr_ps             |                                       |
-| _mm_setzero_pd          |                                       |
-| _mm_setzero_ps          |                                       |
-| _mm_setzero_si128       |                                       |
+| _mm_setzero_pd          | (__m128d)__lsx_vldi(0)                |
+| _mm_setzero_ps          | (__m128)__lsx_vldi(0)                 |
+| _mm_setzero_si128       | __lsx_vldi(0)                         |
 | _mm_shuffle_epi32       |                                       |
 | _mm_shuffle_epi8        |                                       |
 | _mm_shuffle_pd          |                                       |

--- a/docs/migrating_sse.md
+++ b/docs/migrating_sse.md
@@ -27,8 +27,8 @@ Here is a table of a mapping from SSE intrinsics to their LSX counterpart (WIP):
 | _mm_adds_epi8           | __lsx_vsadd_b                         |
 | _mm_adds_epu16          | __lsx_vsadd_hu                        |
 | _mm_adds_epu8           | __lsx_vsadd_bu                        |
-| _mm_addsub_pd           |                                       |
-| _mm_addsub_ps           |                                       |
+| _mm_addsub_pd           | __lsx_vfmadd_d + __lsx_vxor_v         |
+| _mm_addsub_ps           | __lsx_vfmadd_s + __lsx_vxor_v         |
 | _mm_alignr_epi8         |                                       |
 | _mm_and_pd              | __lsx_vand_v                          |
 | _mm_and_ps              | __lsx_vand_v                          |
@@ -41,7 +41,7 @@ Here is a table of a mapping from SSE intrinsics to their LSX counterpart (WIP):
 | _mm_blend_epi16         |                                       |
 | _mm_blend_pd            |                                       |
 | _mm_blend_ps            |                                       |
-| _mm_blendv_epi8         |                                       |
+| _mm_blendv_epi8         | __lsx_vbitsel_v                       |
 | _mm_blendv_pd           |                                       |
 | _mm_blendv_ps           |                                       |
 | _mm_bslli_si128         | __lsx_vbsll_v                         |
@@ -179,8 +179,8 @@ Here is a table of a mapping from SSE intrinsics to their LSX counterpart (WIP):
 | _mm_cvtsd_si64          |                                       |
 | _mm_cvtsd_si64x         |                                       |
 | _mm_cvtsd_ss            |                                       |
-| _mm_cvtsi128_si32       |                                       |
-| _mm_cvtsi128_si64       |                                       |
+| _mm_cvtsi128_si32       | __lsx_vpickve2gr_{b/bu/h/hu/w/wu}     |
+| _mm_cvtsi128_si64       | __lsx_vpickve2gr_{d/du}               |
 | _mm_cvtsi128_si64x      |                                       |
 | _mm_cvtsi32_sd          |                                       |
 | _mm_cvtsi32_si128       |                                       |
@@ -216,8 +216,8 @@ Here is a table of a mapping from SSE intrinsics to their LSX counterpart (WIP):
 | _mm_extract_epi64       |                                       |
 | _mm_extract_epi8        |                                       |
 | _mm_extract_ps          |                                       |
-| _mm_floor_pd            |                                       |
-| _mm_floor_ps            |                                       |
+| _mm_floor_pd            |__lsx_vfrintrm_d                       |
+| _mm_floor_ps            |__lsx_vfrintrm_s                       |
 | _mm_floor_sd            |                                       |
 | _mm_floor_ss            |                                       |
 | _mm_hadd_epi16          |                                       |

--- a/docs/migrating_sse.md
+++ b/docs/migrating_sse.md
@@ -27,8 +27,8 @@ Here is a table of a mapping from SSE intrinsics to their LSX counterpart (WIP):
 | _mm_adds_epi8           | __lsx_vsadd_b                         |
 | _mm_adds_epu16          | __lsx_vsadd_hu                        |
 | _mm_adds_epu8           | __lsx_vsadd_bu                        |
-| _mm_addsub_pd           | __lsx_vfmadd_d + __lsx_vxor_v         |
-| _mm_addsub_ps           | __lsx_vfmadd_s + __lsx_vxor_v         |
+| _mm_addsub_pd           |                                       |
+| _mm_addsub_ps           |                                       |
 | _mm_alignr_epi8         |                                       |
 | _mm_and_pd              | __lsx_vand_v                          |
 | _mm_and_ps              | __lsx_vand_v                          |
@@ -41,7 +41,7 @@ Here is a table of a mapping from SSE intrinsics to their LSX counterpart (WIP):
 | _mm_blend_epi16         |                                       |
 | _mm_blend_pd            |                                       |
 | _mm_blend_ps            |                                       |
-| _mm_blendv_epi8         | __lsx_vbitsel_v                       |
+| _mm_blendv_epi8         |                                       |
 | _mm_blendv_pd           |                                       |
 | _mm_blendv_ps           |                                       |
 | _mm_bslli_si128         | __lsx_vbsll_v                         |
@@ -179,8 +179,8 @@ Here is a table of a mapping from SSE intrinsics to their LSX counterpart (WIP):
 | _mm_cvtsd_si64          |                                       |
 | _mm_cvtsd_si64x         |                                       |
 | _mm_cvtsd_ss            |                                       |
-| _mm_cvtsi128_si32       | __lsx_vpickve2gr_{b/bu/h/hu/w/wu}     |
-| _mm_cvtsi128_si64       | __lsx_vpickve2gr_{d/du}               |
+| _mm_cvtsi128_si32       | __lsx_vpickve2gr_w                    |
+| _mm_cvtsi128_si64       | __lsx_vpickve2gr_d                    |
 | _mm_cvtsi128_si64x      |                                       |
 | _mm_cvtsi32_sd          |                                       |
 | _mm_cvtsi32_si128       |                                       |
@@ -216,8 +216,8 @@ Here is a table of a mapping from SSE intrinsics to their LSX counterpart (WIP):
 | _mm_extract_epi64       |                                       |
 | _mm_extract_epi8        |                                       |
 | _mm_extract_ps          |                                       |
-| _mm_floor_pd            |__lsx_vfrintrm_d                       |
-| _mm_floor_ps            |__lsx_vfrintrm_s                       |
+| _mm_floor_pd            | __lsx_vfrintrm_d                      |
+| _mm_floor_ps            | __lsx_vfrintrm_s                      |
 | _mm_floor_sd            |                                       |
 | _mm_floor_ss            |                                       |
 | _mm_hadd_epi16          |                                       |


### PR DESCRIPTION
X86

![fe8b72eaed3ebb483e163b49aa90e7e](https://github.com/jiegec/unofficial-loongarch-intrinsics-guide/assets/56055887/ec235ffa-6d28-4c05-8dde-5b3700842fb0)

![ad2324f23e79c89771a5db2ebefcc6e](https://github.com/jiegec/unofficial-loongarch-intrinsics-guide/assets/56055887/4d2a5f43-3ff7-4e06-b76d-ecf063f4218b)

![410c42c7e8bfca1ff3f0cc4b9ab7a19](https://github.com/jiegec/unofficial-loongarch-intrinsics-guide/assets/56055887/abe323ee-fcd0-426c-afb9-e548ddd45728)

![3a0c999a53c44931da3d7f0f29d0a35](https://github.com/jiegec/unofficial-loongarch-intrinsics-guide/assets/56055887/fcbec0bd-5da8-4996-a5a6-3f01b119cf30)
LoongArch

![ed383c4457607527756aca8537c83f6](https://github.com/jiegec/unofficial-loongarch-intrinsics-guide/assets/56055887/4444ebff-6049-4034-97d5-436bc161f896)

![22670e8d777031764fa9622fa4005fd](https://github.com/jiegec/unofficial-loongarch-intrinsics-guide/assets/56055887/8f0395cb-2ba0-4cd9-a853-295d161afeef)

![a95fe179dcd69d8e19d1ff40755b2ea](https://github.com/jiegec/unofficial-loongarch-intrinsics-guide/assets/56055887/1b32db12-21a0-4c8b-831c-533398116797)

![8d9ab195799d3ccddbc63bbb31e3e60](https://github.com/jiegec/unofficial-loongarch-intrinsics-guide/assets/56055887/cc54834f-4107-4ac1-acfe-796fcdb30d65)

