### PR TITLE
remove content area width limit of the readthedocs theme

### DIFF
--- a/docs/main.css
+++ b/docs/main.css
@@ -1,3 +1,7 @@
 [v-cloak] {
   display: none
 }
+
+.wy-nav-content {
+  max-width: none;
+}


### PR DESCRIPTION
Remove the 800px content area width limit of the readthedocs theme, allowing the main content to adapt to the browser width.